### PR TITLE
Fix webpack babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,12 @@ module.exports = async (env, options) => {
         {
           test: /\.js$/,
           exclude: /node_modules/,
-          use: "babel-loader"
+          use: {
+            loader: "babel-loader", 
+            options: {
+              presets: ["@babel/preset-env"]
+            }
+          }
         },
         {
           test: /\.html$/,


### PR DESCRIPTION
Office.onReady() callback was using an arrow function which is an ES6 feature not supported on Internet Explorer.

Fix the webpack babel-loader configuration to properly emit ES5 code.