### PR TITLE
Delete more typescript entries using convert script

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -7,6 +7,7 @@ const hosts = ["excel", "onenote", "outlook", "powerpoint", "project", "word"];
 const path = require("path");
 const util = require("util");
 const testPackages = [
+  "@babel/preset-typescript",
   "@types/mocha",
   "@types/node",
   "current-processes",
@@ -14,7 +15,9 @@ const testPackages = [
   "office-addin-mock",
   "office-addin-test-helpers",
   "office-addin-test-server",
+  "ts-loader",
   "ts-node",
+  "typescript",
 ];
 const readFileAsync = util.promisify(fs.readFile);
 const unlinkFileAsync = util.promisify(fs.unlink);
@@ -169,6 +172,7 @@ async function deleteSupportFiles() {
   await unlinkFileAsync("./convertToSingleHost.js");
   await unlinkFileAsync(".npmrc");
   await unlinkFileAsync("package-lock.json");
+  await unlinkFileAsync("tsconfig.json"); // used only for test file building in js project
 }
 
 /**


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
Updating the convertToSingleHost.js script to remove typescript entires in package.json and the extra tsconfig.json file that aren't needed in a JavaScript project after the tests are removed

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
Yes.  The tsconfig.json file is deleted and less packages are listed in the packate.json file

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Probably not.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran the script and verified the resulting project changes.  Also ran automated tests.